### PR TITLE
Evaluate Dhall expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
 # dhaml
+
+`dhaml` is a better alternative to YAML templating. It allows [Dhall][dhall]
+expressions to be embedded within YAML documents using the `!dhall` [tag][tag]
+and it will always substitute the expression with another valid YAML value.
+This has several benefits over traditional YAML templating approaches:
+
+- **Resistant to injection attacks** - Dhall expressions are always substituted
+  with a valid YAML value or the program will return a non-zero exit code.
+  There's also no need to manually escape or indent the output of an
+  expression.
+- **Type safety** - Dhall expressions are statically typed. This allows type
+  annotations to be used to ensure that values match the expected type.
+- **Import resolution** - Dhall expressions can be imported from local files or
+  from a URL. This allows complex expressions to be moved into dedicated
+  `.dhall` files or turned into a library.
+
+## Usage
+
+Start with an input file containing a Dhall value:
+
+```bash
+$ cat input.dhall
+```
+```dhall
+{ string = "foo"
+, number = 2
+}
+```
+
+Use the `!dhall` tag to embed Dhall expressions. The input expression from
+`input.dhall` will be bound to the variable `x` which may then be used in
+subsequent expressions:
+
+```bash
+$ cat template.yaml
+```
+```yaml
+data:
+  string: !dhall x.name
+  number: !dhall 10 * x.number + 5
+  record: !dhall |
+    { a = "abc"
+    , b = True
+    }
+```
+
+Evaluate all Dhall expressions in the YAML file with `dhaml`:
+
+```bash
+$ dhaml template.yaml <<< ./input.dhall
+```
+```yaml
+config:
+  string: foo
+  number: 35
+  record:
+    a: abc
+    b: true
+```
+
+[dhall]: https://dhall-lang.org
+[tag]: https://yaml.org/spec/1.2/spec.html#id2761292

--- a/dhaml.cabal
+++ b/dhaml.cabal
@@ -15,4 +15,20 @@ executable dhaml
   hs-source-dirs:      src
   main-is:             Main.hs
   default-language:    Haskell2010
-  build-depends:       base >= 4.7 && < 5
+  ghc-options:         -Wall
+  build-depends:
+      base       >= 4.7 && < 5
+    , aeson
+    , bytestring
+    , conduit
+    , containers
+    , dhall      >= 1.26.0
+    , dhall-json >= 1.4.1
+    , directory
+    , exceptions
+    , filepath
+    , libyaml
+    , resourcet
+    , text
+    , transformers
+    , yaml

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,5 +1,116 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main where
+
+import Control.Exception (Exception, throwIO)
+import Control.Monad.Catch (catch)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Resource (ResourceT, runResourceT)
+import Control.Monad.Trans.State (StateT, modify, runStateT)
+import Data.Aeson (Value)
+import Data.ByteString.Char8 (ByteString)
+import qualified Data.ByteString.Char8 as BS
+import Data.Char (isSpace)
+import Data.Conduit (ConduitT, awaitForever, runConduit, yield, (.|))
+import Data.Conduit.List (sourceList)
+import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8)
+import qualified Data.Yaml as Y
+import qualified Dhall as D
+import qualified Dhall.Core as D
+import qualified Dhall.Import as D
+import qualified Dhall.JSON as D
+import qualified Dhall.Parser as D
+import qualified Dhall.TypeCheck as D
+import System.Environment (getArgs)
+import System.Exit (exitFailure)
+import System.FilePath.Posix (takeDirectory)
+import System.IO (char8, hPutStrLn, hSetEncoding, stderr, stdout)
+import Text.Libyaml (Event(..))
+import qualified Text.Libyaml as LY
+
+type M = StateT ParseState (ResourceT IO)
+
+data ParseState = ParseState
+    { hasErrors :: Bool
+    }
+
+initialState :: ParseState
+initialState = ParseState False
+
+data DhamlException
+    = DhamlJSONError  String
+    | DhamlParseError String
+    | DhamlTypeError  String
+
+instance Show DhamlException where
+    show (DhamlJSONError  s) = s
+    show (DhamlParseError s) = s
+    show (DhamlTypeError  s) = s
+
+instance Exception DhamlException
+
+eitherThrow :: (Exception e, Show a) => (String -> e) -> Either a b -> IO b
+eitherThrow e (Left  a) = throwIO . e $ show a
+eitherThrow _ (Right b) = return b
 
 main :: IO ()
 main = do
-  putStrLn "-"
+    hSetEncoding stdout char8
+    hSetEncoding stderr char8
+
+    args <- getArgs
+    file <- case args of
+        [x] -> return x
+        _   -> hPutStrLn stderr "usage: dhaml yaml-file" >> exitFailure
+
+    dhall <- decodeUtf8 <$> BS.getContents
+    expr  <- if T.all isSpace dhall
+        then return Nothing
+        else Just <$> D.inputExpr dhall
+
+    yaml  <- encode $ LY.decodeFile file .| processEvents (takeDirectory file) expr
+    putStr $ BS.unpack yaml
+
+-- | Process events and evaluate any Dhall expressions
+processEvents :: FilePath -> Maybe (D.Expr D.Src D.X) -> ConduitT Event Event M ()
+processEvents filepath input = awaitForever $ \event -> do
+    case event of
+        EventScalar expr (LY.UriTag "!dhall") _ _ -> do
+            events <- lift $ catch (liftIO $ dhallToEvents filepath input expr) (handler event)
+            sourceList events
+        _ ->
+            yield event
+
+-- | Print any errors as the YAML file is being parsed
+handler :: MonadIO m => Event -> DhamlException -> StateT ParseState m [Event]
+handler originalEvent e = do
+    liftIO . hPutStrLn stderr $ show e
+    modify $ \x -> x { hasErrors = True }
+    return [originalEvent]
+
+-- | Convert a Dhall 'Expr' from a 'ByteString' into a stream of 'Event's
+dhallToEvents :: FilePath -> Maybe (D.Expr D.Src D.X) -> ByteString -> IO [Event]
+dhallToEvents filepath input bs = do
+    expr1 <- eitherThrow DhamlParseError . D.exprFromText "(expression)" $ decodeUtf8 bs
+    expr2 <- D.loadRelativeTo filepath D.UseSemanticCache $ expr1
+    let expr3 = maybe expr2 (\x -> D.subst (D.V "x" 0) x expr2) input
+    _     <- eitherThrow DhamlTypeError $ D.typeOf expr3
+    expr4 <- exprToValue $ D.normalize expr3
+    return $ Y.objToEvents Y.defaultEncodeOptions expr4 []
+
+-- | Convert a Dhall 'Expr' into an Aeson 'Value'
+exprToValue :: D.Expr s D.X -> IO Value
+exprToValue expr = do
+    let expr1 = D.convertToHomogeneousMaps (D.Conversion "mapKey" "mapValue") expr
+    expr2 <- eitherThrow DhamlJSONError $ D.handleSpecialDoubles D.UseYAMLEncoding expr1
+    eitherThrow DhamlJSONError $ D.dhallToJSON expr2
+
+-- | Encode a stream of 'Event's as a 'ByteString'
+encode :: ConduitT () Event M () -> IO ByteString
+encode events = do
+    result <- runResourceT $ runStateT (runConduit $ events .| LY.encode) initialState
+    if hasErrors $ snd result
+        then exitFailure
+        else return $ fst result

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,11 @@
 resolver: lts-14.7
 packages:
 - .
+extra-deps:
+- dhall-1.26.0@sha256:0f559ab8ed9d7b7f1ed0e2a99a9aadee00d8c6c63b92e9be209d84f7f4197b10,33247
+- dhall-json-1.4.1@sha256:5b0dac356e84d03e855aa4e8aa455532c4c4a274154e26756ae77ebbc82c89a4,5398
+- git: git@github.com:robbiemcmichael/yaml.git
+  commit: f7fecb0febd212fbbd5a7778290203684e3c9ef0
+  subdirs:
+  - libyaml
+  - yaml

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,53 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: dhall-1.26.0@sha256:0f559ab8ed9d7b7f1ed0e2a99a9aadee00d8c6c63b92e9be209d84f7f4197b10,33247
+    pantry-tree:
+      size: 221712
+      sha256: cbd35293fc6b2ef77e5d64fca3775b2915aea86ad0c3425e08d21c950fcd06ea
+  original:
+    hackage: dhall-1.26.0@sha256:0f559ab8ed9d7b7f1ed0e2a99a9aadee00d8c6c63b92e9be209d84f7f4197b10,33247
+- completed:
+    hackage: dhall-json-1.4.1@sha256:5b0dac356e84d03e855aa4e8aa455532c4c4a274154e26756ae77ebbc82c89a4,5398
+    pantry-tree:
+      size: 3387
+      sha256: 77290c47daa5960e967ff219ce9c44ffd3035e64acd6a1d42268eb366b2c4264
+  original:
+    hackage: dhall-json-1.4.1@sha256:5b0dac356e84d03e855aa4e8aa455532c4c4a274154e26756ae77ebbc82c89a4,5398
+- completed:
+    subdir: libyaml
+    cabal-file:
+      size: 2090
+      sha256: cd13f5e93f8b55bf58914ef30363a82debefd9a1b251f2848f1d66a8f0392a7b
+    name: libyaml
+    version: 0.1.1.0
+    git: git@github.com:robbiemcmichael/yaml.git
+    pantry-tree:
+      size: 5594
+      sha256: 863805229e5e3f3e21ba6dd9f0cea6e1764011560abc469aeae2e453de6901ca
+    commit: f7fecb0febd212fbbd5a7778290203684e3c9ef0
+  original:
+    subdir: libyaml
+    git: git@github.com:robbiemcmichael/yaml.git
+    commit: f7fecb0febd212fbbd5a7778290203684e3c9ef0
+- completed:
+    subdir: yaml
+    cabal-file:
+      size: 5109
+      sha256: 72072aac48b081b87948ad7ac7a19d47f7a4d2989625ceefb9cae7fb4740ea6e
+    name: yaml
+    version: 0.11.2.0
+    git: git@github.com:robbiemcmichael/yaml.git
+    pantry-tree:
+      size: 2100
+      sha256: d5fb13596dcbb3b97ee59039244bbcdf2b7bf045a5b6192b6dd0b76c433c0ca0
+    commit: f7fecb0febd212fbbd5a7778290203684e3c9ef0
+  original:
+    subdir: yaml
+    git: git@github.com:robbiemcmichael/yaml.git
+    commit: f7fecb0febd212fbbd5a7778290203684e3c9ef0
 snapshots:
 - completed:
     size: 523700


### PR DESCRIPTION
Treats any YAML values with the `!dhall` tag as Dhall expressions and evaluates them, substituting a YAML encoded version of the result.

Reads an expression from `stdin` and binds the fully nomalised result to the variable `x` which can be used in the embedded expressions. This is done for both ergonomic reasons and for performance reasons as each embedded expression is evaluated independently so repeated imports may be too slow (particularly URL imports).